### PR TITLE
Update Jenkinsfile_docker - make sure subfolder in RLreport is owned by jenkins

### DIFF
--- a/Jenkinsfile_docker
+++ b/Jenkinsfile_docker
@@ -19,6 +19,7 @@ pipeline {
                 script {
                     sh '''
                     echo $WORKSPACE
+                    mkdir -p "$WORKSPACE/RLreport/$BUILD_NUMBER"
                     docker run --rm -u \$(id -u):\$(id -g) \
                     -v "$WORKSPACE/target:/packages:ro" \
                     -v "$WORKSPACE/RLreport/$BUILD_NUMBER:/report" \


### PR DESCRIPTION
Create the RLreport build directory before running the Docker container so that the directory is owned by jenkins, not root. Without this line and with standalone Jenkins (not Jenkins in a container), the directory created underneath the RLreport directory is owned by root since it's created implicitly by the docker run command. Docker runs as jenkins when running in the jenkins container but runs as root usually.